### PR TITLE
Bug/166200403/springboard incomplete invoice fix

### DIFF
--- a/app/jobs/spree_springboard/export_gift_card_job.rb
+++ b/app/jobs/spree_springboard/export_gift_card_job.rb
@@ -13,7 +13,8 @@ module SpreeSpringboard
         gift_card.springboard_export!
       end
     rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: "Export GiftCard #{gift_card.code}" })
+      Raven.extra_context(exporter_gift_card: gift_card.code)
+
       raise error
     end
   end

--- a/app/jobs/spree_springboard/export_order_job.rb
+++ b/app/jobs/spree_springboard/export_order_job.rb
@@ -5,7 +5,8 @@ module SpreeSpringboard
     def perform(order)
       order.springboard_export! if order.springboard_id.blank?
     rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: "Order #{order.number}" })
+      Raven.extra_context(order_number: order.number)
+
       raise error
     end
   end

--- a/app/jobs/spree_springboard/full_inventory_import_job.rb
+++ b/app/jobs/spree_springboard/full_inventory_import_job.rb
@@ -6,7 +6,7 @@ module SpreeSpringboard
       job = SpreeSpringboard::InventoryImport::Full.new
       job.perform
     rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: 'Full Inventory Import' })
+      Raven.capture_exception(error)
     ensure
       job.unlock if job.in_progress?
     end

--- a/app/jobs/spree_springboard/import_returns_job.rb
+++ b/app/jobs/spree_springboard/import_returns_job.rb
@@ -4,9 +4,6 @@ module SpreeSpringboard
 
     def perform
       Spree::ReturnAuthorization.springboard_import_last_day!
-    rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: 'Import New Returns' })
-      raise error
     end
   end
 end

--- a/app/jobs/spree_springboard/import_variant_job.rb
+++ b/app/jobs/spree_springboard/import_variant_job.rb
@@ -5,9 +5,6 @@ module SpreeSpringboard
     def perform
       import_manager = Spree::Variant.springboard_import_class.new
       import_manager.import_all_perform(SpreeSpringboard.client[:items])
-    rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: 'Variants Import' })
-      raise error
     end
   end
 end

--- a/app/jobs/spree_springboard/incremental_inventory_import_job.rb
+++ b/app/jobs/spree_springboard/incremental_inventory_import_job.rb
@@ -6,7 +6,7 @@ module SpreeSpringboard
       job = SpreeSpringboard::InventoryImport::Incremental.new
       job.perform
     rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: 'Incremental Inventory Import' })
+      Raven.capture_exception(error)
     ensure
       job.unlock if job.in_progress?
     end

--- a/app/jobs/spree_springboard/invoice_order_job.rb
+++ b/app/jobs/spree_springboard/invoice_order_job.rb
@@ -8,7 +8,8 @@ module SpreeSpringboard
         order.springboard_invoice!
       end
     rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: "Order #{order.number}" })
+      Raven.extra_context(order_number: order.number)
+
       raise error
     end
   end

--- a/app/jobs/spree_springboard/update_gift_card_job.rb
+++ b/app/jobs/spree_springboard/update_gift_card_job.rb
@@ -5,7 +5,8 @@ module SpreeSpringboard
     def perform(gift_card)
       gift_card.springboard_adjust_balance!
     rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: "Update GiftCard #{gift_card.code}" })
+      Raven.extra_context(updated_gift_card: gift_card.code)
+
       raise error
     end
   end

--- a/app/jobs/spree_springboard/update_variant_job.rb
+++ b/app/jobs/spree_springboard/update_variant_job.rb
@@ -4,9 +4,6 @@ module SpreeSpringboard
 
     def perform
       Spree::Variant.springboard_import_attributes!
-    rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: 'Update Variant' })
-      raise error
     end
   end
 end

--- a/app/model/concerns/spree/springboard_resource_import.rb
+++ b/app/model/concerns/spree/springboard_resource_import.rb
@@ -26,7 +26,9 @@ module Spree
         import_manager.import_all!
       rescue StandardError => error
         class_name = name.demodulize.titleize.pluralize
-        ExceptionNotifier.notify_exception(error, data: { msg: "Import #{class_name} Error" })
+
+        Raven.extra_context(import_class_name: class_name)
+
         raise error
       end
     end

--- a/app/model/spree/return_authorization_decorator.rb
+++ b/app/model/spree/return_authorization_decorator.rb
@@ -12,7 +12,8 @@ module Spree
       import_manager.import_last_three_days!
     rescue StandardError => error
       class_name = name.demodulize.titleize.pluralize
-      ExceptionNotifier.notify_exception(error, data: { msg: "Import #{class_name} Error" })
+      Raven.extra_context(import_class_name: class_name)
+
       raise error
     end
   end

--- a/app/model/spree/variant_decorator.rb
+++ b/app/model/spree/variant_decorator.rb
@@ -9,9 +9,6 @@ module Spree
 
       import_manager = springboard_import_class.new
       import_manager.import_attributes!
-    rescue StandardError => error
-      ExceptionNotifier.notify_exception(error, data: { msg: 'Import Variant attributes Error' })
-      raise error
     end
   end
 end

--- a/lib/spree_springboard/inventory_import/base.rb
+++ b/lib/spree_springboard/inventory_import/base.rb
@@ -71,7 +71,8 @@ module SpreeSpringboard
       # Log handler
       #
       def log(error, params)
-        ExceptionNotifier.notify_exception(error, params)
+        Raven.extra_context(params)
+        Raven.capture_exception(error)
       end
 
       #

--- a/lib/spree_springboard/resource/base.rb
+++ b/lib/spree_springboard/resource/base.rb
@@ -19,7 +19,8 @@ module SpreeSpringboard
       # Log handler
       #
       def log(error, params)
-        ExceptionNotifier.notify_exception(error, params)
+        Raven.extra_context(params)
+        Raven.capture_exception(error)
       end
     end
   end

--- a/lib/spree_springboard/resource/export/order.rb
+++ b/lib/spree_springboard/resource/export/order.rb
@@ -44,6 +44,7 @@ module SpreeSpringboard
             if invoice_springboard_id.present? && order.springboard_element[:status] != 'closed'
               order.line_items.springboard_not_synced.
                 each { |line_item| line_item.springboard_export!(parent: order) }
+
               springboard_invoice_complete!(order)
             end
 

--- a/lib/spree_springboard/resource/export/order.rb
+++ b/lib/spree_springboard/resource/export/order.rb
@@ -46,7 +46,8 @@ module SpreeSpringboard
               each { |line_item| line_item.springboard_export!(parent: order) }
               springboard_invoice_complete!(order)
             end
-            invoice_springboard_id
+           
+             invoice_springboard_id
           end
         end
 

--- a/lib/spree_springboard/resource/export/order.rb
+++ b/lib/spree_springboard/resource/export/order.rb
@@ -43,10 +43,10 @@ module SpreeSpringboard
             invoice_springboard_id = order.child_springboard_id('invoice')
             if invoice_springboard_id.present? && order.springboard_element[:status] != 'closed'
               order.line_items.springboard_not_synced.
-              each { |line_item| line_item.springboard_export!(parent: order) }
+                each { |line_item| line_item.springboard_export!(parent: order) }
               springboard_invoice_complete!(order)
             end
-           
+
              invoice_springboard_id
           end
         end

--- a/lib/spree_springboard/resource/export/order.rb
+++ b/lib/spree_springboard/resource/export/order.rb
@@ -34,9 +34,18 @@ module SpreeSpringboard
         def springboard_invoice!(order)
           if springboard_can_invoice?(order)
             invoice_springboard_id = springboard_invoice_create!(order)
-
             springboard_invoice_line_items_create!(order, invoice_springboard_id) if invoice_springboard_id.present?
             springboard_invoice_complete!(order) if invoice_springboard_id.present?
+            invoice_springboard_id
+          # If the order has been invoiced AND it's open:
+          # attempt to resync line_items and complete the order.
+          elsif springboard_invoiced(order)
+            invoice_springboard_id = order.child_springboard_id('invoice')
+            if invoice_springboard_id.present? && order.springboard_element[:status] != 'closed'
+              order.line_items.springboard_not_synced.
+              each { |line_item| line_item.springboard_export!(parent: order) }
+              springboard_invoice_complete!(order)
+            end
             invoice_springboard_id
           end
         end

--- a/lib/spree_springboard/resource/import/base.rb
+++ b/lib/spree_springboard/resource/import/base.rb
@@ -36,8 +36,6 @@ module SpreeSpringboard
           springboard_resources = import_client.get.body.results
           import_springboard_resources(springboard_resources)
           true
-        rescue StandardError => error
-          log(error, data: { msg: 'Import Last Day Error' })
         end
 
         #

--- a/spree_springboard.gemspec
+++ b/spree_springboard.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
 
   spree_version = '~> 3.3.0'
-  spec.add_dependency 'exception_notification'
+  spec.add_dependency 'sentry-raven'
   spec.add_dependency 'spree_api',         spree_version
   spec.add_dependency 'spree_backend',     spree_version
   spec.add_dependency 'spree_core',        spree_version


### PR DESCRIPTION
Supposing that the sentry branch will be merged this was based off of it.

Adding alternative path to the `springboard_invoice!` method so invoices can be re-synced/closed for circumstances where the invoice has been created but is not complete/closed.