### PR TITLE
Show resource as part of the springboard export log.

### DIFF
--- a/app/controllers/spree/admin/springboard_logs_controller.rb
+++ b/app/controllers/spree/admin/springboard_logs_controller.rb
@@ -8,7 +8,7 @@ module Spree
           id: @springboard_log.id,
           resource_type: @springboard_log.resource_type,
           message_type: @springboard_log.message_type,
-          resource_export_params: @springboard_log.resource_export_params,
+          resource_export_params: @springboard_log.resource_export_params
         }
       end
 

--- a/lib/spree_springboard/resource/export/base.rb
+++ b/lib/spree_springboard/resource/export/base.rb
@@ -26,10 +26,12 @@ module SpreeSpringboard
 
         def sync_request(resource, params)
           client(resource).
-            send(sync_method(resource), export_params(resource, params))
+            send(sync_method(resource), params)
         end
 
         def sync!(resource, params = {})
+          params = export_params(resource, params)
+
           log_params = {
             transaction_id: self.class.transaction_id(resource),
             parent: params[:parent],


### PR DESCRIPTION
Now showing the exported resource as part of the springboard export log for orders.